### PR TITLE
chore(ci): update Maven config and switch to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish package to the Maven Central Repository
+name: Publish package to GitHub Packages
 on:
   workflow_dispatch:
   release:
@@ -7,24 +7,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: carboneio/checkout@main
-      - name: Set up Maven Central Repository
-        uses: carboneio/setup-java@main
+      - uses: actions/checkout@v4
+      - name: Setup Java
+        uses: actions/setup-java@v4
         with:
-          java-version: '21'
+          java-version: '11'
           distribution: 'temurin'
-          server-id: central
-          server-username: ${{ secrets.CENTRAL_USERNAME }} # env variable for username in deploy
-          server-password: ${{ secrets.CENTRAL_PASSWORD }} # env variable for token in deploy
-          gpg-private-key: ${{ secrets.SIGN_KEY }}
-          gpg-passphrase: ${{ secrets.SIGN_KEY_PASS }} # env variable for GPG private key passphrase
-      # - name: Set version
-      #   run: mvn versions:set -DnewVersion=${{ github.event.release.tag_name }}
-      - name: Publish package
-        run: mvn -X --batch-mode deploy -DskipTests
+      - name: Publish to GitHub Packages
+        run: mvn --batch-mode deploy
         env:
-          MAVEN_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
-          MAVEN_CENTRAL_TOKEN: ${{ secrets.CENTRAL_PASSWORD }}
-          SIGN_KEY: ${{ secrets.SIGN_KEY }}
-          SIGN_KEY_PASS: ${{ secrets.SIGN_KEY_PASS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -24,10 +24,17 @@
         </developer>
     </developers>
     <scm>
-        <connection>scm:git:git://github.com/carboneio/carbone-sdk-java.git</connection>
-        <developerConnection>scm:git:ssh://github.com:carboneio/carbone-sdk-java.git</developerConnection>
-        <url>https://github.com/carboneio/carbone-sdk-java/tree/master</url>
+        <connection>scm:git:git://github.com/OneSpark-Insurance/carbone-sdk-java.git</connection>
+        <developerConnection>scm:git:ssh://github.com/OneSpark-Insurance/carbone-sdk-java.git</developerConnection>
+        <url>https://github.com/OneSpark-Insurance/carbone-sdk-java/tree/master</url>
     </scm>
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/OneSpark-Insurance/carbone-sdk-java</url>
+        </repository>
+    </distributionManagement>
     <properties>
         <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
- Update SCM details and add `distributionManagement` in `pom.xml` for GitHub Packages.
- Update GitHub Actions workflow to publish package to GitHub Packages.
- Replace outdated actions and configurations with updated versions.